### PR TITLE
fix: #63 - prevent config.ini corruption with Lock()

### DIFF
--- a/src/pipupgrade/config.py
+++ b/src/pipupgrade/config.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 # imports - standard imports
 import os.path as osp
 import multiprocessing as mp
+from threading import Lock
 import platform
 import json
 
@@ -20,21 +21,42 @@ PATH["DATA"]    = osp.join(PATH["BASE"], "data")
 PATH["CACHE"]   = osp.join(osp.expanduser("~"), ".%s" % NAME)
 
 class Configuration(object):
-    def __init__(self, location = PATH["CACHE"], name = "config"):
-        self.location   = location
-        makedirs(self.location, exist_ok = True)
-        
-        self.name       = "%s.ini" % name
-        
-    @property
-    def config(self):
-        path    = osp.join(self.location, self.name)
-        config  = cp.ConfigParser()
-        
-        if osp.exists(path):
-            config.read(path)
 
-        return config
+    # BUGFIX: #63 Always complains about invalid config.ini - https://github.com/achillesrasquinha/pipupgrade/issues/63
+    #         Use threading.Lock() around disk IO
+    locks = { "readwrite": Lock() }
+
+
+    def __init__(self, location = PATH["CACHE"], name = "config"):
+        self.name     = "%s.ini" % name
+        self.location = location
+        makedirs(self.location, exist_ok = True)
+        self.config   = self.read()
+
+    @classmethod
+    def __del__(self):
+        # Clean up leaked semaphores Lock() before thread exit
+        # This function gets called atexit once per SpawnPoolWorker-1 thread
+        for key in list(self.locks.keys()):
+            self.locks[key].acquire()
+            self.locks[key].release()
+            del self.locks[key]
+
+
+    def read(self):
+        with self.locks['readwrite']:
+            path        = osp.join(self.location, self.name)
+            self.config = cp.ConfigParser()
+            if osp.exists(path):
+                self.config.read(path)
+        return self.config
+
+    def write(self):
+        with self.locks['readwrite']:
+            path = osp.join(self.location, self.name)
+            with open(path, "w") as f:
+                self.config.write(f)
+
 
     def get(self, section, key):
         config = self.config
@@ -48,25 +70,20 @@ class Configuration(object):
         value = auto_typecast(config.get(section, key))
 
         return value
-        
+
     def set(self, section, key, value, force = False):
         config = self.config
         value  = str(value)
 
         if not config.has_section(section):
             config.add_section(section)
-            config.set(section, key, value)
-        else:
-            if not config.has_option(section, key):
-                config.set(section, key, value)
-            else:
-                if force:
-                    config.set(section, key, value)
 
-        path = osp.join(self.location, self.name)
-        with open(path, "w") as f:
-            config.write(f)
-        
+        if force or not config.has_option(section, key):
+            config.set(section, key, value)
+            self.write()
+
+
+
 class Settings(object):
     _DEFAULTS = {
               "version": __version__,


### PR DESCRIPTION
Fixes #

## Proposed Changes
  - add Lock() around Configuration IO to prevent config.ini corruption