### PR TITLE
fix: duplicate included requirements

### DIFF
--- a/src/pipupgrade/commands/__init__.py
+++ b/src/pipupgrade/commands/__init__.py
@@ -178,6 +178,8 @@ def _command(*args, **kwargs):
                         requirements)
                     requirements += flatten(results)
 
+                requirements = list(set(requirements))
+
             logger.info("Requirements found: %s" % requirements)
             
             with parallel.no_daemon_pool(processes = a.jobs) as pool:


### PR DESCRIPTION
Fixes #

## Proposed Changes
If using the `--project` flag and included requirements are present, the parent requirement would be included twice in the requirements list (once due to the initial search in the project directory, once due to the included check)
The user was then prompted multiple times to accept/decline updates for the same requirements file

The `requirements` list can be filtered to be unique paths only, before proceeding further