### PR TITLE
fix: issue #89

### DIFF
--- a/src/pipupgrade/commands/__init__.py
+++ b/src/pipupgrade/commands/__init__.py
@@ -73,7 +73,7 @@ ARGUMENTS = dict(
 def command(**ARGUMENTS):
     try:
         return _command(**ARGUMENTS)
-    except:
+    except Exception:
         cli.echo()
 
         traceback_str = traceback.format_exc()


### PR DESCRIPTION
This makes the error handler only display a message when there is an Exception, instead of on expected "exceptions" such as SystemExit and KeyboardInterrupt.

Fixes #89

## Proposed Changes

  - Use `Exception` in the catch-all error case to avoid catching non-Errors