### PR TITLE
fix: #71 Package object has no attribute 'name'

### DIFF
--- a/tests/pipupgrade/test__pip.py
+++ b/tests/pipupgrade/test__pip.py
@@ -2,10 +2,10 @@
 from __future__ import absolute_import
 
 # imports - standard imports
-import subprocess
+import os
 
 # imports - test imports
-import pytest
+from testutils import PATH
 
 # imports - module imports
 from pipupgrade         import _pip
@@ -43,8 +43,17 @@ def test_call(tmpdir):
 
     _pip.call("install", "pipupgrade")
     assert_pip_call(_pip.call("install", "pipupgrade", quiet = True))
-    
+
     _pip.call("install", "pipupgrade", log = path)
     assert tempfile.read()
 
     # assert_pip_call(_pip.call("list", output = True))
+
+
+def test_parse_requirements():
+    """`parse_requirements` returns an iterable of `InstallRequirement`"""
+    filepath = os.path.join(PATH["DATA"], "project", "requirements.txt")
+
+    requirements = list(_pip.parse_requirements(filepath, session="hack"))
+
+    assert all([isinstance(req, _pip.InstallRequirement) for req in requirements])


### PR DESCRIPTION
Fixes #71

## Proposed Changes

From pip 20.X.X onwards, `parse_requirements` returns a generator of ParsedRequirement objects, instead of the InstallRequirement objects as previously
Need to wrap `parse_requirements` to return `InstallRequirement` objects instead