### PR TITLE
fix-93

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,3 +6,4 @@ pytest-travis-fold
 tox
 coveralls
 pluggy<1,>=0.12.0
+mock; python_version < "3.3"

--- a/src/pipupgrade/model/package.py
+++ b/src/pipupgrade/model/package.py
@@ -81,11 +81,13 @@ class Package(object):
 		elif isinstance(package, _pip.InstallRequirement):
 			self.name            = package.name
 
-			if hasattr(package, "req"):
-				if hasattr(package.req, "specifier"):
-					self.current_version = str(package.req.specifier)
+			# Check if requirement is pinned, falling back to the installed
+			# version, then finally str(Specifier)
+			if package.is_pinned:
+				self.current_version = next(iter(package.specifier)).version
 			else:
-				self.current_version = package.installed_version
+				self.current_version = package.installed_version or str(package.specifier)
+
 		elif isinstance(package, dict):
 			self.name            = package["name"]
 			self.current_version = package["version"]

--- a/tests/pipupgrade/commands/test_commands__init__.py
+++ b/tests/pipupgrade/commands/test_commands__init__.py
@@ -1,4 +1,5 @@
 import os.path as osp
+import sys
 
 # imports - compatibility imports
 from pipupgrade.commands    import _command as command
@@ -15,6 +16,9 @@ def test_command_self(capfd):
     out, err = capfd.readouterr()
     assert "upto date." in out
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Function never completes, related to #78"
+)
 def test_command(capfd):
     project      = osp.join(PATH["DATA"], "project")
     requirements = osp.join(project, "requirements.txt")


### PR DESCRIPTION
Fixes #93

## Proposed Changes

- If `--requirements` or `--project` flags are used, current_version for
    Packages was equal to the specifier in the requirements file
    eg. requests==2.24.0 showed current_version as `==2.24.0` rather than
    just `2.24.0`
    This then caused the `upgrade_type` check later to fail (as the `==`
    version prefix made the version difference calculation incorrect
    
    Requirements will now include the version only if an exact version is
    specified, otherwise the installed version is used.
    If not installed, the entire specifier is used (eg. `~=1.0`)

  - `test_command` hangs forever on Windows (see #78), so CI runs for
    the full 6hrs for each Windows run. Until #78 is resolved, test should be skipped so the Windows CI can at least test the rest of the codebase