### PR TITLE
Quote path to pip executable

### DIFF
--- a/src/pipupgrade/_pip.py
+++ b/src/pipupgrade/_pip.py
@@ -43,11 +43,11 @@ def _get_pip_executable(multiple = False):
         exec_ = which(pip_)
         if exec_:
             if not multiple:
-                return exec_
+                return '"' + exec_ + '"'
             else:
                 exec_ = osp.realpath(exec_)
                 if exec_ not in execs:
-                    execs.append(exec_)
+                    execs.append('"' + exec_ + '"')
 
     if not execs: # pragma: no cover
         raise ValueError("pip executable not found.")

--- a/src/pipupgrade/_pip.py
+++ b/src/pipupgrade/_pip.py
@@ -45,9 +45,9 @@ def _get_pip_executable(multiple = False):
             if not multiple:
                 return '"' + exec_ + '"'
             else:
-                exec_ = osp.realpath(exec_)
+                exec_ = '"' + osp.realpath(exec_) + '"'
                 if exec_ not in execs:
-                    execs.append('"' + exec_ + '"')
+                    execs.append(exec_)
 
     if not execs: # pragma: no cover
         raise ValueError("pip executable not found.")

--- a/src/pipupgrade/commands/__init__.py
+++ b/src/pipupgrade/commands/__init__.py
@@ -144,7 +144,7 @@ def _command(*args, **kwargs):
         cli.echo(cli_format("Checking...", cli.YELLOW), file = file_)
 
         pip_path    = a.pip_path or [ ]
-        pip_path    = [which(p) for p in pip_path] or _pip._PIP_EXECUTABLES
+        pip_path    = ['"' + which(p) + '"' for p in pip_path] or _pip._PIP_EXECUTABLES
 
         logger.info("`pip` executables found: %s" % pip_path)
         


### PR DESCRIPTION
This lets us call pip if it's in a virtualenv with a name that contains spaces.

## Proposed Changes

  - All strings specifying paths to pip executables now begin and end with a quote character